### PR TITLE
Add teardown & scaling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compose-deploy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Docker Compose deployment tool using ssh2",
   "bin": {
     "compose-deploy": "build/index.js",

--- a/src/commands/teardown.ts
+++ b/src/commands/teardown.ts
@@ -1,0 +1,80 @@
+import { CommandModule } from 'yargs';
+import { ITeardownCommandArgs } from '../types';
+import { loadConfig } from '../util/config';
+import { readFileOptional } from '../util/fs';
+import {
+  connect,
+  getRemotePaths,
+  remoteFileExists,
+  exec,
+  disconnect
+} from '../util/ssh';
+
+export const teardownCommand: CommandModule<{}, ITeardownCommandArgs> = {
+  command: 'teardown',
+  aliases: ['down', 'rm'],
+  describe: 'Stop all running deployments',
+  builder(b) {
+    return b
+      .option('config', {
+        alias: 'cfg',
+        default: '.',
+        describe: 'Configuration file directory',
+        string: true
+      })
+      .option('volumes', {
+        alias: 'v',
+        default: true,
+        describe: 'Remove named & anonymous volumes',
+        boolean: true
+      })
+      .option('orphans', {
+        alias: 'remove-orphans',
+        default: true,
+        describe: 'Remove containers for undefined services',
+        boolean: true
+      });
+  },
+  async handler(args) {
+    const { config, orphans, volumes } = args;
+    const { name, targets } = await loadConfig(config);
+
+    const teardownOptions = `${orphans ? '--remove-orphans' : ''} ${
+      volumes ? '--volumes' : ''
+    }`;
+
+    for (const deploymentTargetIndex in targets) {
+      const { privateKeyFile, username, ...rest } = targets[
+        deploymentTargetIndex
+      ];
+      console.log(
+        `💥 Tearing down deployment ${parseInt(deploymentTargetIndex) + 1} of ${
+          targets.length
+        }`
+      );
+
+      const privateKey = await readFileOptional(privateKeyFile);
+
+      console.log('📡 Connecting to target server');
+      await connect({ ...rest, username, privateKey });
+
+      const { remoteFilePath, remoteDirPath } = getRemotePaths(username, name);
+
+      if (!(await remoteFileExists(remoteFilePath))) {
+        continue;
+      }
+
+      console.log('🎳 Tearing down...');
+
+      await exec(
+        `cd ${remoteDirPath} && docker-compose down ${teardownOptions}`
+      );
+
+      disconnect();
+
+      console.log('✅ Teardown completed');
+    }
+
+    console.log('✨ Teardown completed for all deployment targets!');
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 
 import yargs from 'yargs';
+import chalk from 'chalk';
+
 import { initCommand } from './commands/init';
 import { deployCommand } from './commands/deploy';
-import chalk from 'chalk';
+import { teardownCommand } from './commands/teardown';
 
 const handleError = (err: Error) => {
   console.error(chalk.red(err.message));
-  console.error(err.stack);
   process.exit(1);
 };
 
@@ -16,9 +17,9 @@ process.on('unhandledRejection', handleError);
 
 const { argv } = yargs
   .scriptName('compose-deploy')
-  .alias('*', 'help')
   .command(initCommand)
   .command(deployCommand)
+  .command(teardownCommand)
   .locale('en')
   .showHelpOnFail(false)
   .help();

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,13 @@ export interface IInitCommandArgs {
 
 export interface IDeployCommandArgs {
   config: string;
+  scale: string[];
+}
+
+export interface ITeardownCommandArgs {
+  config: string;
+  volumes: boolean;
+  orphans: boolean;
 }
 
 /*

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -17,3 +17,6 @@ export const fileExists = async (path: string) => {
     return false;
   }
 };
+
+export const readFileOptional = (filePath?: string) =>
+  filePath ? readFile(filePath) : undefined;

--- a/src/util/ssh.ts
+++ b/src/util/ssh.ts
@@ -76,3 +76,14 @@ export const remoteFileExists = (path: string) =>
       });
     });
   });
+
+export const getRemotePaths = (username: string, projectName: string) => {
+  const remoteDirPath = `/home/${username}/compose-deploy/${projectName}`;
+  const remoteFileName = `docker-compose.yml`;
+  const remoteFilePath = `${remoteDirPath}/${remoteFileName}`;
+  return {
+    remoteDirPath,
+    remoteFileName,
+    remoteFilePath
+  };
+};


### PR DESCRIPTION
This PR introduces the `teardown` subcommand, used for stopping and removing a running deployment, as well as the `scale` option to the up|deploy subcommand for replicating service instances.