### PR TITLE
Add env-based configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Currently, there's no other way to access your deployments than by checking manu
   - `privateKeyFile` can be used to supply the file path of your private key used for SSH auth
 - `composeFile`: The path of your compose file (defaults to `docker-compose.yml` in your current working directory)
 
+### environment variables
+
+Some SSH connection options are automatically used when present as environment variables, including
+
+- `SSH_AUTH_SOCK`: Path to a UNIX socket created by your running ssh-agent (optional)
+- `COMPOSE_DEPLOY_SSH_PASSPHRASE`, `COMPOSE_DEPLOY_SSH_PASSWORD`, `COMPOSE_DEPLOY_SSH_USER`, `COMPOSE_DEPLOY_SSH_HOST`, `COMPOSE_DEPLOY_SSH_PORT`: Connection-specific options, which can be supplied and overriden by your configuration
+
 ## license
 
 This project is licensed under the [MIT License](LICENSE).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compose-deploy",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Docker Compose deployment tool using ssh2",
   "bin": {
     "compose-deploy": "build/index.js",

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -12,6 +12,7 @@ import {
   remoteFileExists,
   getRemotePaths
 } from '../util/ssh';
+import { fromEnv } from '../util/env';
 
 export const deployCommand: CommandModule<{}, IDeployCommandArgs> = {
   command: 'deploy',
@@ -68,7 +69,7 @@ export const deployCommand: CommandModule<{}, IDeployCommandArgs> = {
 
       // Pass all config keys into connect
       console.log('📡 Connecting to target server');
-      await connect({ ...rest, username, privateKey });
+      await connect({ ...fromEnv(), ...rest, username, privateKey });
 
       console.log('🥁 Connected! Copying Compose file...');
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,8 +13,10 @@ export interface IDeploymentTarget {
   host: string;
   username: string;
   password?: string;
-  privateKeyFile?: string;
   passphrase?: string;
+
+  // Custom config properties
+  privateKeyFile?: string;
 }
 
 /*

--- a/src/util/env.ts
+++ b/src/util/env.ts
@@ -1,0 +1,26 @@
+/**
+ * Returns ssh2-compatible connection options parsed from
+ * compose-deploy custom environment variables, as well
+ * as ssh-agent's SSH_AUTH_SOCK
+ */
+export function fromEnv() {
+  const {
+    SSH_AUTH_SOCK,
+    COMPOSE_DEPLOY_SSH_PASSPHRASE,
+    COMPOSE_DEPLOY_SSH_PASSWORD,
+    COMPOSE_DEPLOY_SSH_USER,
+    COMPOSE_DEPLOY_SSH_HOST,
+    COMPOSE_DEPLOY_SSH_PORT
+  } = process.env;
+
+  return {
+    host: COMPOSE_DEPLOY_SSH_HOST,
+    port: COMPOSE_DEPLOY_SSH_PORT
+      ? parseInt(COMPOSE_DEPLOY_SSH_PORT)
+      : undefined,
+    agent: SSH_AUTH_SOCK,
+    username: COMPOSE_DEPLOY_SSH_USER,
+    password: COMPOSE_DEPLOY_SSH_PASSWORD,
+    passphrase: COMPOSE_DEPLOY_SSH_PASSPHRASE
+  };
+}


### PR DESCRIPTION
For CI-like situations where you have to configure compose-deploy based on environment variables, for example to use the autogenerated ssh-agent to connect to your deployment target, compose-deploy now supports configuration using environment variables, which can be overridden by your configuration, not the other way round. 